### PR TITLE
BootstrapVueIconsのscriptを削除

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -44,8 +44,6 @@
         <!-- Load Vue followed by BootstrapVue -->
         <script src="//unpkg.com/vue@latest/dist/vue.min.js"></script>
         <script src="//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.min.js"></script>
-        <!-- Load the following for BootstrapVueIcons support -->
-        <script src="//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue-icons.min.js"></script>
         <!-- axios -->
         <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
         <!-- Vuex -->


### PR DESCRIPTION
fontawesomeを追加したため、BootstrapVueIconsのほうの読み込みは削除します。