### PR TITLE
シェルでスペースを認識しないのでクォーテーションで囲む

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,7 +6,7 @@ DEBUG=1
 # Django unique secret key value
 SECRET_KEY=foo
 # Host names to allow access to django apps. separated by spaces if multiple domains
-DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]
+DJANGO_ALLOWED_HOSTS="localhost 127.0.0.1 [::1]"
 
 # Database process name
 DATABASE=postgres


### PR DESCRIPTION
```
source ./.env.development
```
で、エラーが出ていたので修正しました。