### PR TITLE
Upadte disable admin-style browsable interface of django-rest-framework

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -134,9 +134,14 @@ STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 MEDIA_URL = "/mediafiles/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "mediafiles")
 
+# django-rest-framework
 REST_FRAMEWORK = {
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
 }
+
+# disable admin-style browsable interface of django-rest-framework
+if not DEBUG:
+    REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = ('rest_framework.renderers.JSONRenderer', )
 
 # CORS 許可するオリジン
 if DEBUG:  # for DEBUG


### PR DESCRIPTION
django-rest-frameworkのデフォルト表示を管理画面からJSONベースの表示に変更した。
