### PR TITLE
Make $api injected to Vue instance completely ported to typescript

### DIFF
--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -3,7 +3,10 @@
     <b-row align-h="center">
       <b-col cols="12" md="8">
         <h1>
-          <img :src="require(`@/assets/images/logo/${logoLargeSrc}`)" :alt="$t('title')" />
+          <img
+            :src="require(`@/assets/images/logo/${logoLargeSrc}`)"
+            :alt="$t('title')"
+          />
         </h1>
         <div class="text-center">#owaranai</div>
         <div class="text-center">
@@ -131,7 +134,6 @@ export default Vue.extend({
   },
   methods: {
     getDataAndDrawChart() {
-      // @ts-ignore
       this.$api
         .$get('http://127.0.0.1:8000/api/v1/meetings/')
         .then((res: Meeting[]) => {
@@ -154,7 +156,7 @@ export default Vue.extend({
           this.drawChart()
           this.drawBarChart()
         })
-        .catch((e: any) => {
+        .catch((e) => {
           console.error(e)
         })
     },

--- a/frontend/pages/try_meter.vue
+++ b/frontend/pages/try_meter.vue
@@ -428,7 +428,6 @@ export default Vue.extend({
     },
     submitSave() {
       this.busy = true
-      // @ts-ignore
       this.$api({
         method: 'post',
         url: 'http://127.0.0.1:8000/api/v1/meetings/',
@@ -448,7 +447,7 @@ export default Vue.extend({
           this.busy = false
           this.showCompletedModal = true
         })
-        .catch((e: any) => {
+        .catch((e) => {
           console.error(e)
         })
     },

--- a/frontend/plugins/api.ts
+++ b/frontend/plugins/api.ts
@@ -1,15 +1,23 @@
-// @ts-ignore
-export default function ({ $axios }, inject) {
+import { Plugin } from '@nuxt/types'
+import { NuxtAxiosInstance } from '@nuxtjs/axios'
+
+const plugin: Plugin = function ({ $axios }, inject) {
   const api = $axios.create({
     timeout: 5000,
     headers: {
       'Content-Type': 'application/json',
-      'X-Requested-With': 'XMLHttpRequest'
-    }
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+    xsrfCookieName: 'csrftoken',
+    xsrfHeaderName: 'X-CSRFTOKEN',
   })
 
-  api.xsrfCookieName = 'csrftoken'
-  api.xsrfHeaderName = 'X-CSRFTOKEN'
-
   inject('api', api)
+}
+export default plugin
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $api: NuxtAxiosInstance
+  }
 }


### PR DESCRIPTION
close #86 

- Vue インスタンスに inject された $api を typescript に完全移植

cf: https://typescript.nuxtjs.org/ja/cookbook/plugins/